### PR TITLE
Stylesheet for burgerking's partner page

### DIFF
--- a/burgerking.scss
+++ b/burgerking.scss
@@ -1,0 +1,45 @@
+.burgerking-cms-page {
+  // Variables
+  $dark: #858585;
+  $base: #121212;
+  $accent: #f7f2ed;
+  // Color Utilities
+  .base-bg { background-color: $dark; }
+  .accent-bg { background-color: $accent; }
+  .button {
+    background-color: $base;
+    color: $color-white-base;
+  }
+  a {
+    color: $color-black-base;
+    &:hover, &:active {
+      color: darken($base, 10%);
+      & svg use {
+        fill: darken($base, 10%);
+      }
+    }
+  }
+  .program-options {
+    .multi-card:not(:first-child):not(:last-child) {
+      .icon-container {
+        background: $base;
+      }
+    }
+  }
+  .sticky-nav {
+    .login {
+      color: $base;
+    }
+    .login:hover {
+      color: darken($base, 10%);
+    }
+  }
+  .overlay {
+    background-color: rgba(255,255,255,0.6);
+  }
+  svg {
+    circle {
+      fill: $color-black-base;
+    }
+  }
+}


### PR DESCRIPTION
## This PR adds styles for burgerking
 * Base: #121212
 * Dark: #858585
 * Overlay: 0.6

_Submitted by rachel.warbelow@guildeducation.com on 4/27/2020 17:42:18_