### PR TITLE
Stylesheet for turing's partner page 5/1/2020 12:36:57

### DIFF
--- a/app/assets/turing.scss
+++ b/app/assets/turing.scss
@@ -1,0 +1,52 @@
+.turing-cms-page {
+  // Variables
+  $dark-colors: #343434;
+  $base: #121212;
+  $accent: #f7f2ed;
+
+  // Color Utilities
+  .base-bg { background-color: $dark; }
+  .accent-bg { background-color: $accent; }
+
+  .button {
+    background-color: $base;
+    color: $color-white-base;
+  }
+
+  a {
+    color: $color-black-base;
+    &:hover, &:active {
+      color: darken($base, 10%);
+      & svg use {
+        fill: darken($base, 10%);
+      }
+    }
+  }
+
+  .program-options {
+    .multi-card:not(:first-child):not(:last-child) {
+      .icon-container {
+        background: $base;
+      }
+    }
+  }
+
+  .sticky-nav {
+    .login {
+      color: $base;
+    }
+    .login:hover {
+      color: darken($base, 10%);
+    }
+  }
+
+  .overlay {
+    background-color: rgba(255,255,255,0.6);
+  }
+
+  svg {
+    circle {
+      fill: $color-black-base;
+    }
+  }
+}


### PR DESCRIPTION
## Styles for turing
 * Base: #121212
 * Dark: #343434
 * Overlay: 0.6

_Submitted by rachel@turing.io on 5/1/2020 12:36:57_