### PR TITLE
Stylesheet for cello's partner page (5/1/2020 12:37:50)

### DIFF
--- a/app/assets/cello.scss
+++ b/app/assets/cello.scss
@@ -1,0 +1,52 @@
+.cello-cms-page {
+  // Variables
+  $dark-colors: #919191;
+  $base: #575757;
+  $accent: #f7f2ed;
+
+  // Color Utilities
+  .base-bg { background-color: $dark; }
+  .accent-bg { background-color: $accent; }
+
+  .button {
+    background-color: $base;
+    color: $color-white-base;
+  }
+
+  a {
+    color: $color-black-base;
+    &:hover, &:active {
+      color: darken($base, 10%);
+      & svg use {
+        fill: darken($base, 10%);
+      }
+    }
+  }
+
+  .program-options {
+    .multi-card:not(:first-child):not(:last-child) {
+      .icon-container {
+        background: $base;
+      }
+    }
+  }
+
+  .sticky-nav {
+    .login {
+      color: $base;
+    }
+    .login:hover {
+      color: darken($base, 10%);
+    }
+  }
+
+  .overlay {
+    background-color: rgba(255,255,255,0.3);
+  }
+
+  svg {
+    circle {
+      fill: $color-black-base;
+    }
+  }
+}


### PR DESCRIPTION
## Styles for cello
 * Base: #575757
 * Dark: #919191
 * Overlay: 0.3

_Submitted by rachel@turing.io on 5/1/2020 12:37:50_