### PR TITLE
Stylesheet for walmart's partner page (5/1/2020 12:43:36)

### DIFF
--- a/app/assets/walmart.scss
+++ b/app/assets/walmart.scss
@@ -1,0 +1,47 @@
+.walmart-cms-page {
+  // Variables
+  $dark-colors: #414141;
+  $base: #141414;
+  $accent: #f7f2ed;
+
+  // Color Utilities
+  .base-bg { background-color: $dark; }
+  .accent-bg { background-color: $accent; }
+
+  .button {
+    background-color: $base;
+    color: $color-white-base;
+  }
+
+  a {
+    color: $color-black-base;
+    &:hover, &:active {
+      color: darken($base, 10%);
+      & svg use {
+        fill: darken($base, 10%);
+      }
+    }
+  }
+
+  .program-options {
+    .multi-card:not(:first-child):not(:last-child) {
+      .icon-container {
+        background: $base;
+      }
+    }
+  }
+
+  .sticky-nav {
+    .login {
+      color: $base;
+    }
+    .login:hover {
+      color: darken($base, 10%);
+    }
+  }
+
+  .overlay {
+    background-color: rgba(255,255,255,0.5);
+  }
+
+}


### PR DESCRIPTION
## Styles for walmart
 * Base: #141414
 * Dark: #414141
 * Overlay: 0.5

_Submitted by rachel@turing.io on 5/1/2020 12:43:36_