### PR TITLE
Stylesheet for coldstone's partner page (5/1/2020 12:44:26)

### DIFF
--- a/app/assets/coldstone.scss
+++ b/app/assets/coldstone.scss
@@ -1,0 +1,47 @@
+.coldstone-cms-page {
+  // Variables
+  $dark-colors: #828282;
+  $base: #343434;
+  $accent: #f7f2ed;
+
+  // Color Utilities
+  .base-bg { background-color: $dark; }
+  .accent-bg { background-color: $accent; }
+
+  .button {
+    background-color: $base;
+    color: $color-white-base;
+  }
+
+  a {
+    color: $color-black-base;
+    &:hover, &:active {
+      color: darken($base, 10%);
+      & svg use {
+        fill: darken($base, 10%);
+      }
+    }
+  }
+
+  .program-options {
+    .multi-card:not(:first-child):not(:last-child) {
+      .icon-container {
+        background: $base;
+      }
+    }
+  }
+
+  .sticky-nav {
+    .login {
+      color: $base;
+    }
+    .login:hover {
+      color: darken($base, 10%);
+    }
+  }
+
+  .overlay {
+    background-color: rgba(255,255,255,0.2);
+  }
+
+}


### PR DESCRIPTION
## Styles for coldstone
 * Base: #343434
 * Dark: #828282
 * Overlay: 0.2

_Submitted by rachel@turing.io on 5/1/2020 12:44:26_