### PR TITLE
Stylesheet for morningstar's partner page (5/1/2020 13:14:25)

### DIFF
--- a/app/assets/stylesheets/pages/morningstar-cms.scss
+++ b/app/assets/stylesheets/pages/morningstar-cms.scss
@@ -1,0 +1,47 @@
+.morningstar-cms-page {
+  // Variables
+  $dark: #888888;
+  $base: #999999;
+  $accent: #f7f2ed;
+
+  // Color Utilities
+  .base-bg { background-color: $dark; }
+  .accent-bg { background-color: $accent; }
+
+  .button {
+    background-color: $base;
+    color: $color-white-base;
+  }
+
+  a {
+    color: $color-black-base;
+    &:hover, &:active {
+      color: darken($base, 10%);
+      & svg use {
+        fill: darken($base, 10%);
+      }
+    }
+  }
+
+  .program-options {
+    .multi-card:not(:first-child):not(:last-child) {
+      .icon-container {
+        background: $base;
+      }
+    }
+  }
+
+  .sticky-nav {
+    .login {
+      color: $base;
+    }
+    .login:hover {
+      color: darken($base, 10%);
+    }
+  }
+
+  .overlay {
+    background-color: rgba(255,255,255,0.6);
+  }
+
+}


### PR DESCRIPTION
## Styles for morningstar
 * Base: #999999
 * Dark: #888888
 * Overlay: 0.6

_Submitted by rachel@turing.io on 5/1/2020 13:14:25_