### PR TITLE
Stylesheet for discover's partner page (5/1/2020 13:56:50)

### DIFF
--- a/app/assets/stylesheets/pages/discover-cms.scss
+++ b/app/assets/stylesheets/pages/discover-cms.scss
@@ -1,0 +1,46 @@
+.discover-cms-page {
+  // Variables
+  $dark: #888888;
+  $base: #999999;
+  $accent: #f7f2ed;
+
+  // Color Utilities
+  .base-bg { background-color: $dark; }
+  .accent-bg { background-color: $accent; }
+
+  .button {
+    background-color: $base;
+    color: $color-white-base;
+  }
+
+  a {
+    color: $color-black-base;
+    &:hover, &:active {
+      color: darken($base, 10%);
+      & svg use {
+        fill: darken($base, 10%);
+      }
+    }
+  }
+
+  .program-options {
+    .multi-card:not(:first-child):not(:last-child) {
+      .icon-container {
+        background: $base;
+      }
+    }
+  }
+
+  .sticky-nav {
+    .login {
+      color: $base;
+    }
+    .login:hover {
+      color: darken($base, 10%);
+    }
+  }
+
+  .overlay {
+    background-color: rgba(255,255,255,0.4);
+  }
+}


### PR DESCRIPTION
## Styles for discover
 * Base: #999999
 * Dark: #888888
 * Overlay: 0.4

_Submitted by rachelwarbelow@gmail.com on 5/1/2020 13:56:50_