### PR TITLE
Stylesheet for testdatetime's partner page (5/5/2020 16:19:52)

### DIFF
--- a/app/assets/stylesheets/pages/testdatetime-cms.scss
+++ b/app/assets/stylesheets/pages/testdatetime-cms.scss
@@ -1,0 +1,44 @@
+.testdatetime-cms-page {
+  // Variables
+  $dark: #111222;
+  $base: #888777;
+  $accent: #999000;
+
+  // Color Utilities
+  .base-bg { background-color: $dark; }
+  .button {
+    background-color: $base;
+    color: $color-white-base;
+  }
+
+  a {
+    color: $color-black-base;
+    &:hover, &:active {
+      color: darken($base, 10%);
+      & svg use {
+        fill: darken($base, 10%);
+      }
+    }
+  }
+
+  .program-options {
+    .multi-card:not(:first-child):not(:last-child) {
+      .icon-container {
+        background: $accent;
+      }
+    }
+  }
+
+  .sticky-nav {
+    .login {
+      color: $base;
+    }
+    .login:hover {
+      color: darken($base, 10%);
+    }
+  }
+
+  .overlay {
+    background-color: rgba(255,255,255,0.8);
+  }
+}


### PR DESCRIPTION
## Styles for testdatetime
 * Base: #888777
 * Dark: #111222
 * Accent: #999000
 * Overlay: 0.8

_Submitted by rachelwarbelow@gmail.com on 5/5/2020 16:19:52_